### PR TITLE
update: Player kick turn & slight decel

### DIFF
--- a/Godot/scenes/enemies/TestEnemy/scripts/controller.gd
+++ b/Godot/scenes/enemies/TestEnemy/scripts/controller.gd
@@ -3,6 +3,9 @@
 extends KinematicBody2D
 class_name Enemy
 
+#descriptive variables
+export var enemy_health: float = 100
+
 # Speed variables
 export var walk_speed: float = 150
 export var gravity: float = 40
@@ -49,6 +52,9 @@ func move():
     
 # Hit by a bullet
 func hit():
+    enemy_health -= 20
+    if enemy_health == 0:
+        print("dead")
     print("Enemy has been hit!")
 
 # Setters and Getters

--- a/Godot/scenes/player/scripts/controller.gd
+++ b/Godot/scenes/player/scripts/controller.gd
@@ -8,8 +8,10 @@ class_name Player
 signal shoot
 
 # Player Movement (Variables)
-export var walk_speed: float = 350
+export var walk_speed: float = 300
 export var run_speed: float = 500
+export var ground_accel: float = 100
+export var friction: float = 0.2
 export var air_accel: float = 45
 export var gravity: float = 40
 export var terminal_velocity: float = 800
@@ -46,6 +48,7 @@ func _physics_process(_delta: float) -> void:
     state_machine.run()
 
 func move():
+    update_look_direction()
     velocity = move_and_slide(velocity, Vector2.UP)
     
 func _update_inputs() -> void:
@@ -70,6 +73,17 @@ func _update_inputs() -> void:
 func apply_gravity():
     if velocity.y <= terminal_velocity:
         velocity.y += gravity
+        
+# Animations and looks
+
+func update_look_direction():
+    if direction == -1:
+        pass
+    if direction == 1:
+        pass
+    if velocity.x and state_machine.active_state.tag != "air":
+        if direction != velocity.x/abs(velocity.x):
+            print("kick turn", direction)
 
 
 # Setters and Getters

--- a/Godot/scenes/player/scripts/state_machine/states/air.gd
+++ b/Godot/scenes/player/scripts/state_machine/states/air.gd
@@ -5,7 +5,7 @@ extends PlayerState
 var max_speed: float = 0
 
 func enter(player: KinematicBody2D):
-    max_speed = abs(player.vx) if abs(player.vx) > 0 else player.walk_speed
+    max_speed = abs(player.vx) if abs(player.vx) > player.walk_speed else player.walk_speed
     .enter(player)
     
 func run(player: KinematicBody2D):

--- a/Godot/scenes/player/scripts/state_machine/states/idle.gd
+++ b/Godot/scenes/player/scripts/state_machine/states/idle.gd
@@ -3,8 +3,12 @@ extends PlayerState
 #Override run function
 func run(player: KinematicBody2D) -> String:
     # Stop the player's motion
-    player.vx = 0
+    if player.vx != 0:
+        player.vx = lerp(player.vx, 0, player.friction)
+    if abs(player.vx) < 1:
+        player.vx = 0
     player.vy = 0
+    player.apply_gravity()
     player.move()
     
     # Return the next state

--- a/Godot/scenes/player/scripts/state_machine/states/run.gd
+++ b/Godot/scenes/player/scripts/state_machine/states/run.gd
@@ -3,7 +3,7 @@
 extends PlayerState
 
 func run(player: KinematicBody2D) -> String:
-    player.vx = player.horizontal_input * player.run_speed
+    player.vx = player.horizontal_input * player.run_speed if player.horizontal_input != 0 else player.vx
     player.apply_gravity()
     player.move()
     

--- a/Godot/scenes/player/scripts/state_machine/states/walk.gd
+++ b/Godot/scenes/player/scripts/state_machine/states/walk.gd
@@ -4,8 +4,7 @@ extends PlayerState
 
 func run(player: KinematicBody2D) -> String:
     player.apply_gravity()
-    if player.horizontal_input != 0:
-        player.vx = player.horizontal_input * player.walk_speed
+    player.vx = player.horizontal_input * player.walk_speed if player.horizontal_input != 0 else player.vx
     player.move()
     
     # Return the next state


### PR DESCRIPTION
# Quick Description

### Work Done:
<!-- What work did you do? Enter it below -->

Merged Evan's enemy health system with a system that decelerates the player ever so slightly in idle which allows for kick turns. There's a slight bug where you can switch the direction quick enough on keyboard that will have to be worked out later.

## Checklist
<!-- Please make sure these have been completed -->
<!-- Add an x in the [ ] to check each item off like this: [x] -->

- [x] I have named my PR using the feat/fix/update naming scheme
- [x] I have linked my work to the ClickUp Task Board via one of [these methods](https://docs.clickup.com/integrations/github)
- [x] My code follows the general guidelines set up, and isn't ugly/all over the place
- [x] I have requested the review of at least one other person and moved my task to the "Needs Review" section of the task board
